### PR TITLE
Fix no data without convocation

### DIFF
--- a/packages/codumacademy-graphql-server/src/models/convocation/schema.ts
+++ b/packages/codumacademy-graphql-server/src/models/convocation/schema.ts
@@ -21,7 +21,8 @@ export const typeDefinitions = `
 `;
 
 export const queries = `
-  currentConvocation: Convocation
+  currentConvocation: Convocation,
+  lastConvocation: Convocation
 `;
 
 export const mutations = ``;
@@ -30,14 +31,28 @@ export const resolvers = {
   Query: {
     currentConvocation: async () => {
       var currentDate = new Date();
-      const convocation = await Convocation.findOne({ where: {
-        fromDate: {
-          $lte: currentDate
-        },
-        toDate: {
-          $gte: currentDate
+      const convocation = await Convocation.findOne({
+        where: {
+          fromDate: {
+            $lte: currentDate
+          },
+          toDate: {
+            $gte: currentDate
+          }
         }
-      }});
+      });
+      if (convocation) return convocation;
+
+      return null;
+    },
+    lastConvocation: async () => {
+      var date = new Date("2018-11-02");
+      console.log(date);
+      const convocation = await Convocation.findOne({
+        where: {
+          toDate: date
+        }
+      });
       if (convocation) return convocation;
 
       return null;
@@ -57,4 +72,4 @@ export const authProtection = {
   Query: {},
   Mutation: {},
   Convocation: {}
-}
+};

--- a/packages/codumacademy-web/app-state/actions/convocation-actions.js
+++ b/packages/codumacademy-web/app-state/actions/convocation-actions.js
@@ -1,12 +1,17 @@
 import currentConvocationQuery from "../query/current-convocation.graphql";
+import lastConvocationQuery from "../query/last-convocation.graphql";
 import { setAppLoading, setPartLoading } from "./app-actions";
 
 export const SET_CONVOCATION = "CONVOCATION/SET_CONVOCATION";
 export const CANCEL_SCHEDULE = "CONVOCATION/CANCEL_SCHEDULE";
 export const SET_CONGRATULATIONS = "CONVOCATION/SET_CONGRATULATIONS";
+export const SET_LAST_CONVOCATION = "CONVOCATION/SET_LAST_CONVOCATION";
 
 export const setCurrentConvocation = value => dispatch =>
   dispatch({ type: SET_CONVOCATION, payload: value });
+
+export const setLastConvocation = value => dispatch =>
+  dispatch({ type: SET_LAST_CONVOCATION, payload: value });
 
 export const getCurrentConvocation = client => dispatch =>
   new Promise(async resolve => {
@@ -23,6 +28,28 @@ export const getCurrentConvocation = client => dispatch =>
         newCurrentConvocation.convocationRequirements || [];
 
       dispatch(setCurrentConvocation(newCurrentConvocation));
+      resolve(newCurrentConvocation);
+    }
+
+    dispatch(setAppLoading(false));
+    dispatch(setPartLoading(false));
+  });
+
+export const getLastConvocation = client => dispatch =>
+  new Promise(async resolve => {
+    dispatch(setAppLoading(true));
+    dispatch(setPartLoading(true));
+    const {
+      data: { lastConvocation }
+    } = await client.query({ query: lastConvocationQuery });
+
+    if (lastConvocation) {
+      const newCurrentConvocation = { ...lastConvocation };
+
+      newCurrentConvocation.convocationRequirements =
+        newCurrentConvocation.convocationRequirements || [];
+
+      dispatch(setLastConvocation(newCurrentConvocation));
       resolve(newCurrentConvocation);
     }
 

--- a/packages/codumacademy-web/app-state/query/last-convocation.graphql
+++ b/packages/codumacademy-web/app-state/query/last-convocation.graphql
@@ -1,0 +1,19 @@
+query lastConvocation {
+  lastConvocation {
+    id
+    description
+    requirements
+    fromDate
+    toDate
+    convocationRequirements {
+      id
+      description
+      helpText
+      success
+      required
+      requiredApprove
+      withQuiz
+      quizId
+    }
+  }
+}

--- a/packages/codumacademy-web/app-state/reducers/convocation-reducer.js
+++ b/packages/codumacademy-web/app-state/reducers/convocation-reducer.js
@@ -1,7 +1,8 @@
 import {
   SET_CONVOCATION,
   CANCEL_SCHEDULE,
-  SET_CONGRATULATIONS
+  SET_CONGRATULATIONS,
+  SET_LAST_CONVOCATION
 } from "../actions/convocation-actions";
 
 const initialState = {
@@ -29,6 +30,11 @@ export default function reducer(state = initialState, action) {
       return {
         ...state,
         showCongratulations: true
+      };
+    case SET_LAST_CONVOCATION:
+      return {
+        ...state,
+        lastConvocation: action.payload
       };
     default:
       return state;

--- a/packages/codumacademy-web/components/UsersResults/UserList/store.js
+++ b/packages/codumacademy-web/components/UsersResults/UserList/store.js
@@ -1,4 +1,4 @@
-import { compose, lifecycle, withHandlers, withProps } from "recompose";// eslint-disable-line
+import { compose, lifecycle, withHandlers, withProps } from "recompose"; // eslint-disable-line
 import { withApollo } from "react-apollo";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";

--- a/packages/codumacademy-web/components/UsersResults/index.js
+++ b/packages/codumacademy-web/components/UsersResults/index.js
@@ -31,7 +31,9 @@ const UsersResults = props => (
       </Helmet>
       <TopNavigation />
       <Container>
-        <Title>Usuarios</Title>
+        <Title>
+          Usuarios {props.isLastConvocation && "de la convocatoria cerrada"}
+        </Title>
         <DownloadIconContainer>
           <DownloadImage
             src="/static/images/icons/file.svg"
@@ -76,7 +78,8 @@ UsersResults.propTypes = {
   currentConvocation: PropTypes.object.isRequired,
   setShowList: PropTypes.func.isRequired,
   downloadExcel: PropTypes.func.isRequired,
-  onCheckRequirement: PropTypes.func.isRequired
+  onCheckRequirement: PropTypes.func.isRequired,
+  isLastConvocation: PropTypes.bool.isRequired
 };
 
 export default withStore(UsersResults);

--- a/packages/codumacademy-web/components/UsersResults/store.js
+++ b/packages/codumacademy-web/components/UsersResults/store.js
@@ -335,7 +335,8 @@ const withRedux = () => {
         ? currentConvocation
         : lastConvocation,
     isAppLoading,
-    isPartLoading
+    isPartLoading,
+    isLastConvocation: currentConvocation.convocationRequirements.length === 0
   });
 
   const mapDispatchToProps = (dispatch, props) =>

--- a/packages/codumacademy-web/components/UsersResults/store.js
+++ b/packages/codumacademy-web/components/UsersResults/store.js
@@ -5,7 +5,10 @@ import { bindActionCreators } from "redux";
 // import * as ExportJsonExcel from "js-export-excel";
 
 import { setPartLoading } from "../../app-state/actions/app-actions";
-import { getCurrentConvocation } from "../../app-state/actions/convocation-actions";
+import {
+  getCurrentConvocation,
+  getLastConvocation
+} from "../../app-state/actions/convocation-actions";
 import { getUsersList } from "../../app-state/actions/admin-actions";
 import getUsersListQuery from "../../app-state/query/get-users-complete-list.graphql";
 
@@ -309,6 +312,7 @@ const funcs = withHandlers({
 const withLifecycles = lifecycle({
   componentDidMount() {
     this.props.getCurrentConvocation();
+    this.props.getLastConvocation();
     this.props.getUsersList();
   }
 });
@@ -316,11 +320,20 @@ const withLifecycles = lifecycle({
 const withRedux = () => {
   const mapStateToProps = ({
     app: { isAppLoading, isPartLoading },
-    convocation: { currentConvocation },
+    convocation: { currentConvocation, lastConvocation },
     admin: { users }
   }) => ({
-    users: users.map(user => getUserResult(currentConvocation, user)),
-    currentConvocation,
+    users: users.map(user => {
+      const convocation =
+        currentConvocation.convocationRequirements.length > 0
+          ? currentConvocation
+          : lastConvocation;
+      return getUserResult(convocation, user);
+    }),
+    currentConvocation:
+      currentConvocation.convocationRequirements.length > 0
+        ? currentConvocation
+        : lastConvocation,
     isAppLoading,
     isPartLoading
   });
@@ -330,6 +343,7 @@ const withRedux = () => {
       {
         setPartLoading,
         getCurrentConvocation: () => getCurrentConvocation(props.client),
+        getLastConvocation: () => getLastConvocation(props.client),
         getUsersList: () => getUsersList(props.client)
       },
       dispatch


### PR DESCRIPTION
***¿Está listo para revisión?:*** SI

## ¿Qué se trabajó?:

Se arreagla bug que no permitia ver la lista de usuarios si la convocatoria esta vencida

## ¿Cómo se trabajó:

se crea un resolver que trae de base de datos la convocatoria dando la fecha de vencimiento de la misma que se quiere traer
se creo un query para traer los datos de la ultima convocatoria cerrada en caso de que no exista convocatoria actual
se crea un action que llama este query
se crea un reducer que guarda la ultima convocatoria vencida
en el store se llama `lastConvocation` si `currentConvocation` no existe aun

## ¿Cómo QA puede verificar esto?:

Intentando acceder al admin cuando la convocatoria esta vencida y no hay una actual
